### PR TITLE
Added pccc-core module that supports PCCC commands encapsulated in CIP

### DIFF
--- a/pccc-core/pom.xml
+++ b/pccc-core/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.digitalpetri.enip</groupId>
+		<artifactId>enip</artifactId>
+		<version>1.1.3-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>pccc-core</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.digitalpetri.enip</groupId>
+			<artifactId>enip-core</artifactId>
+			<version>1.1.3-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.digitalpetri.enip</groupId>
+			<artifactId>enip-client</artifactId>
+			<version>1.1.3-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-buffer</artifactId>
+			<version>4.0.36.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.7</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccClient.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccClient.java
@@ -1,0 +1,117 @@
+package com.digitalpetri.enip.pccc;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpetri.enip.EtherNetIpClient;
+import com.digitalpetri.enip.EtherNetIpClientConfig;
+import com.digitalpetri.enip.commands.SendRRData;
+import com.digitalpetri.enip.cpf.CpfItem;
+import com.digitalpetri.enip.cpf.CpfPacket;
+import com.digitalpetri.enip.cpf.NullAddressItem;
+import com.digitalpetri.enip.cpf.UnconnectedDataItemRequest;
+import com.digitalpetri.enip.cpf.UnconnectedDataItemResponse;
+import com.digitalpetri.enip.pccc.services.ExecutePcccAsCipService;
+import com.digitalpetri.enip.pccc.services.PcccService;
+import com.digitalpetri.enip.pccc.services.PcccServiceInvoker;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+
+public class PcccClient extends EtherNetIpClient implements PcccServiceInvoker {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final AtomicInteger sequenceNumber = new AtomicInteger(0);
+
+	public PcccClient(EtherNetIpClientConfig config) {
+		super(config);
+	}
+
+	@Override
+	public <T> CompletableFuture<T> invokeUnconnected(PcccService<T> service) {
+		return invokeUnconnected(service, 0);
+	}
+
+	@Override
+	public <T> CompletableFuture<T> invokeUnconnected(PcccService<T> service, int maxRetries) {
+		CompletableFuture<T> future = new CompletableFuture<>();
+
+		ExecutePcccAsCipService<T> uss = new ExecutePcccAsCipService<T>(service, nextSequenceNumber(), getConfig());
+
+		return invokeUnconnected(uss, future, 0, maxRetries);
+	}
+
+	private <T> CompletableFuture<T> invokeUnconnected(PcccService<T> service, CompletableFuture<T> future, int count,
+			int max) {
+		sendUnconnectedData(service::encodeRequest).whenComplete((buffer, ex) -> {
+			if (buffer != null) {
+				try {
+					T response = service.decodeResponse(buffer);
+					future.complete(response);
+				} catch (PcccService.PartialResponseException e) {
+					invokeUnconnected(service, future, count, max);
+				} catch (PcccResponseException e) {
+					if (e.getGeneralStatus() == 0x01) {
+						boolean requestTimedOut = Arrays.stream(e.getAdditionalStatus()).anyMatch(i -> i == 0x0204);
+
+						if (requestTimedOut && count < max) {
+							logger.info("Unconnected request timed out; retrying, count={}, max={}", count, max);
+							invokeUnconnected(service, future, count + 1, max);
+						} else {
+							future.completeExceptionally(e);
+						}
+					} else {
+						future.completeExceptionally(e);
+					}
+				} catch (Exception responseEx) {
+					future.completeExceptionally(responseEx);
+				} finally {
+					ReferenceCountUtil.release(buffer);
+				}
+			} else {
+				future.completeExceptionally(ex);
+			}
+		});
+
+		return future;
+	}
+
+	public CompletableFuture<ByteBuf> sendUnconnectedData(ByteBuf data) {
+		return sendUnconnectedData((buffer) -> buffer.writeBytes(data));
+	}
+
+	public CompletableFuture<ByteBuf> sendUnconnectedData(Consumer<ByteBuf> dataEncoder) {
+		CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+
+		UnconnectedDataItemRequest dataItem = new UnconnectedDataItemRequest(dataEncoder);
+		CpfPacket packet = new CpfPacket(new NullAddressItem(), dataItem);
+
+		sendRRData(new SendRRData(packet)).whenComplete((command, ex) -> {
+			if (command != null) {
+				CpfItem[] items = command.getPacket().getItems();
+
+				if (items.length == 2 && items[0].getTypeId() == NullAddressItem.TYPE_ID
+						&& items[1].getTypeId() == UnconnectedDataItemResponse.TYPE_ID) {
+					ByteBuf data = ((UnconnectedDataItemResponse) items[1]).getData();
+
+					future.complete(data);
+				} else {
+					future.completeExceptionally(new Exception("received unexpected items"));
+				}
+			} else {
+				future.completeExceptionally(ex);
+			}
+		});
+
+		return future;
+	}
+
+	private short nextSequenceNumber() {
+		return (short) sequenceNumber.incrementAndGet();
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccDataType.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccDataType.java
@@ -1,0 +1,47 @@
+package com.digitalpetri.enip.pccc;
+
+import java.util.Optional;
+
+public enum PcccDataType {
+	BIT(1),
+
+	BIT_STRING(2),
+
+	BYTE_STRING(3),
+
+	INT(4),
+
+	TIMER(5),
+
+	COUNTER(6),
+
+	CONTROL(7),
+
+	REAL(8),
+
+	ARRAY(9),
+
+	ADDRESS(15),
+
+	BCD(16);
+
+	private final int code;
+
+	PcccDataType(int code) {
+		this.code = code;
+	}
+
+	public final int getCode() {
+		return code;
+	}
+
+	public static Optional<PcccDataType> fromCode(int code) {
+		for (PcccDataType dataType : values()) {
+			if (dataType.getCode() == code) {
+				return Optional.of(dataType);
+			}
+		}
+		return Optional.empty();
+
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccExtendedStatusCodes.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccExtendedStatusCodes.java
@@ -1,0 +1,37 @@
+package com.digitalpetri.enip.pccc;
+
+import com.google.common.collect.ImmutableMap;
+
+public abstract class PcccExtendedStatusCodes {
+	private PcccExtendedStatusCodes() {
+	}
+
+	private static final ImmutableMap<Integer, String> STATUS_CODES;
+
+	static {
+		STATUS_CODES = ImmutableMap.<Integer, String>builder().put(0x1, "A field has an illegal value.")
+				.put(0x2, "Less levels specified in address than minimum for any address.")
+				.put(0x3, "More levels specified in address than system supports.").put(0x4, "Symbol not found.")
+				.put(0x5, "Symbol is of improper format.").put(0x6, "Address doesn't point to something usable.")
+				.put(0x7, "File is wrong size.")
+				.put(0x8, "Cannot complete request, situation has changed since the start of the command.")
+				.put(0x9, "Data or file is too large.").put(0xA, "Transaction size plus word address is too large.")
+				.put(0xB, "Access denied, improper privilege.")
+				.put(0xC, "Condition cannot be generated - resource is not available")
+				.put(0xD, "Condition already exists - resource is already available.")
+				.put(0xE, "Command cannot be executed.").put(0xF, "Histogram overflow.").put(0x10, "No access.")
+				.put(0x11, "Illegal data type.").put(0x12, "Invalid parameter or invalid data.")
+				.put(0x13, "Address reference exists to deleted area.")
+				.put(0x14, "Command execution failure for unknown reason; possible PLC-3 histogram overflow.")
+				.put(0x15, "Data conversion error.")
+				.put(0x16, "Scanner not able to communicate with 1771 rack adapter.").put(0x17, "Type mismatch.")
+				.put(0x18, "1771 module response was not valid.").put(0x19, "Duplicated label.")
+				.put(0x22, "Remote rack fault.").put(0x23, "Timeout.").put(0x1A, "File is open; another node owns it.")
+				.put(0x1B, "Another node is the program owner.").put(0x1E, "Data table element protection violation.")
+				.put(0x1F, "Temporary internal problem.").build();
+	}
+
+	public static String getName(int statusCode) {
+		return STATUS_CODES.getOrDefault(statusCode, "Unknown error response.");
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccResponseException.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccResponseException.java
@@ -1,0 +1,80 @@
+package com.digitalpetri.enip.pccc;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.digitalpetri.enip.cip.CipStatusCodes;
+
+public class PcccResponseException extends Exception {
+	private static final long serialVersionUID = 7250921816036988324L;
+
+	private final int generalStatus;
+	private final int[] additionalStatus;
+	private final int pcccStatus;
+	private final int extendedStatus;
+
+	public PcccResponseException(int generalStatus, int[] additionalStatus) {
+		this.generalStatus = generalStatus;
+		this.additionalStatus = additionalStatus;
+		this.pcccStatus = -1;
+		this.extendedStatus = -1;
+	}
+
+	public PcccResponseException(int pcccStatus, int extendedStatus) {
+		this.pcccStatus = pcccStatus;
+		this.extendedStatus = extendedStatus;
+		this.generalStatus = -1;
+		this.additionalStatus = new int[] {};
+	}
+
+	public int getGeneralStatus() {
+		return generalStatus;
+	}
+
+	public int[] getAdditionalStatus() {
+		return additionalStatus;
+	}
+
+	public int getPcccStatus() {
+		return pcccStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		StringBuilder sb = new StringBuilder();
+
+		if (generalStatus > -1) {
+			sb.append(String.format("generalStatus=0x%02X", generalStatus));
+			CipStatusCodes.getName(generalStatus).ifPresent(name -> sb.append(" [").append(name).append("] "));
+
+			List<String> as = Arrays.stream(additionalStatus).mapToObj(a -> String.format("0x%04X", a))
+					.collect(Collectors.toList());
+
+			if (!as.isEmpty()) {
+				String additional = "[" + String.join(",", as) + "]";
+				sb.append(", additional=").append(additional);
+			}
+		} else if (pcccStatus > -1) {
+			sb.append(String.format("pcccStatus=0x%02X", pcccStatus));
+			sb.append(" [").append(PcccStatusCodes.getName(pcccStatus)).append("] ");
+
+			if (extendedStatus > -1) {
+				sb.append(String.format(", extendedStatus=0x%02X", extendedStatus));
+				sb.append(" [").append(PcccExtendedStatusCodes.getName(extendedStatus)).append("] ");
+			}
+		}
+
+		return sb.toString();
+	}
+
+	public static Optional<PcccResponseException> extract(Throwable ex) {
+		if (ex instanceof PcccResponseException) {
+			return Optional.of((PcccResponseException) ex);
+		} else {
+			Throwable cause = ex.getCause();
+			return cause != null ? extract(cause) : Optional.empty();
+		}
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccStatusCodes.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/PcccStatusCodes.java
@@ -1,0 +1,28 @@
+package com.digitalpetri.enip.pccc;
+
+import com.google.common.collect.ImmutableMap;
+
+public abstract class PcccStatusCodes {
+	private PcccStatusCodes() {
+	}
+
+	private static final ImmutableMap<Integer, String> STATUS_CODES;
+
+	static {
+		STATUS_CODES = ImmutableMap.<Integer, String>builder().put(0x10, "Illegal command or format.")
+				.put(0x20, "Host has a problem and will not communicate.")
+				.put(0x30, "Remote node host is missing, disconnected, or shut down.")
+				.put(0x40, "Host could not complete function due to hardware fault.")
+				.put(0x50, "Addressing problem or memory protect rungs.")
+				.put(0x60, "Function not allowed due to command protection selection.")
+				.put(0x70, "Processor is in Program mode.")
+				.put(0x80, "Compatibility mode file missing or communication zone problem.")
+				.put(0x90, "Remote node cannot buffer command.").put(0xA0, "Wait ACK (1775-KA buffer full).")
+				.put(0xB0, "Remote node problem due to download.").put(0xC0, "Wait ACK (1775-KA buffer full).")
+				.put(0xF0, "Error code in the EXT STS byte.").build();
+	}
+
+	public static String getName(int statusCode) {
+		return STATUS_CODES.getOrDefault(statusCode, "Unknown error response.");
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/ExecutePcccAsCipService.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/ExecutePcccAsCipService.java
@@ -1,0 +1,117 @@
+package com.digitalpetri.enip.pccc.services;
+
+import com.digitalpetri.enip.EtherNetIpClientConfig;
+import com.digitalpetri.enip.cip.epath.EPath.PaddedEPath;
+import com.digitalpetri.enip.cip.epath.LogicalSegment.ClassId;
+import com.digitalpetri.enip.cip.epath.LogicalSegment.InstanceId;
+import com.digitalpetri.enip.cip.structs.MessageRouterRequest;
+import com.digitalpetri.enip.cip.structs.MessageRouterResponse;
+import com.digitalpetri.enip.pccc.PcccResponseException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+
+//refer to https://www.rockwellautomation.com/resources/downloads/rockwellautomation/pdf/sales-partners/technology-licensing/CIPandPCCC_v1_1.pdf
+//refer section Delivery of PCCC in CIP
+public class ExecutePcccAsCipService<T> implements PcccService<T> {
+	public static final int SERVICE_CODE = 0x4B;
+
+	public static final int REQUEST_ID_SIZE = 0x7;
+	public static final int PCCC_TYPED_CMD = 0x0F;
+	public static final int PCCC_STATUS = 0x0;
+
+	private static final PaddedEPath CONNECTION_MANAGER_PATH = new PaddedEPath(new ClassId(0x67), new InstanceId(0x01));
+
+	private final PcccService<T> service;
+	private final short sequenceNumber;
+	private final EtherNetIpClientConfig clientConfig;
+
+	public ExecutePcccAsCipService(PcccService<T> service, short sequenceNumber, EtherNetIpClientConfig clientConfig) {
+		this.service = service;
+		this.sequenceNumber = sequenceNumber;
+		this.clientConfig = clientConfig;
+	}
+
+	@Override
+	public void encodeRequest(ByteBuf buffer) {
+		MessageRouterRequest request = new MessageRouterRequest(SERVICE_CODE, CONNECTION_MANAGER_PATH, this::encode);
+
+		MessageRouterRequest.encode(request, buffer);
+	}
+
+	private ByteBuf encode(ByteBuf buffer) {
+		buffer.writeByte(REQUEST_ID_SIZE);
+		buffer.writeShort(clientConfig.getVendorId());
+		buffer.writeInt(clientConfig.getSerialNumber());
+
+		int bytesWritten = encodeEmbeddedService(buffer);
+
+		// pad byte if length was odd
+		if (bytesWritten % 2 != 0)
+			buffer.writeByte(0x00);
+
+		return buffer;
+	}
+
+	private int encodeEmbeddedService(ByteBuf buffer) {
+		buffer.writeByte(PCCC_TYPED_CMD);
+		buffer.writeByte(PCCC_STATUS);
+		buffer.writeShort(sequenceNumber);
+
+		// embedded message
+		int messageStartIndex = buffer.writerIndex();
+		service.encodeRequest(buffer);
+
+		// go back and update length
+		int bytesWritten = buffer.writerIndex() - messageStartIndex;
+
+		return bytesWritten;
+	}
+
+	@Override
+	public T decodeResponse(ByteBuf buffer) throws PcccResponseException, PartialResponseException {
+		MessageRouterResponse response = MessageRouterResponse.decode(buffer);
+
+		int generalStatus = response.getGeneralStatus();
+
+		try {
+			if (generalStatus == 0x0)
+				return decode(response);
+			else
+				throw new PcccResponseException(generalStatus, response.getAdditionalStatus());
+		} finally {
+			ReferenceCountUtil.release(response.getData());
+		}
+	}
+
+	private T decode(MessageRouterResponse response) throws PcccResponseException, PartialResponseException {
+		ByteBuf buffer = response.getData().retain();
+
+		buffer.readUnsignedByte(); // request id size always 7
+		buffer.readUnsignedShort(); // vendor id
+		buffer.readInt(); // skip vendor SR no
+
+		return decodeEmbeddedservice(buffer);
+	}
+
+	private T decodeEmbeddedservice(ByteBuf buffer) throws PcccResponseException, PartialResponseException {
+		buffer.readUnsignedByte(); // PCCC command
+		int pcccStatus = buffer.readUnsignedByte(); // PCCC status
+		buffer.readUnsignedShort(); // sequence number
+
+		if (pcccStatus == 0x0) {
+			ByteBuf data = buffer.isReadable() ? buffer.readSlice(buffer.readableBytes()).retain()
+					: Unpooled.EMPTY_BUFFER;
+
+			return service.decodeResponse(data);
+		} else {
+			int extendedStatus = -1;
+
+			if (pcccStatus == 0xF0 && buffer.isReadable())
+				extendedStatus = buffer.readUnsignedByte();
+
+			throw new PcccResponseException(pcccStatus, extendedStatus);
+		}
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/PcccService.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/PcccService.java
@@ -1,0 +1,17 @@
+package com.digitalpetri.enip.pccc.services;
+
+import com.digitalpetri.enip.pccc.PcccResponseException;
+
+import io.netty.buffer.ByteBuf;
+
+public interface PcccService<T> {
+	void encodeRequest(ByteBuf buffer);
+
+	T decodeResponse(ByteBuf buffer) throws PcccResponseException, PartialResponseException;
+
+	public static final class PartialResponseException extends Exception {
+		private static final long serialVersionUID = 3767099761970910476L;
+
+		public static final PartialResponseException INSTANCE = new PartialResponseException();
+	}
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/PcccServiceInvoker.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/PcccServiceInvoker.java
@@ -1,0 +1,29 @@
+package com.digitalpetri.enip.pccc.services;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface PcccServiceInvoker {
+	/**
+	 * Invoke a service request using PCCC unconnected messaging.
+	 *
+	 * @param service
+	 *            the service to invoke.
+	 * @return a {@link CompletableFuture} containing the eventual service
+	 *         response or failure.
+	 */
+	<T> CompletableFuture<T> invokeUnconnected(PcccService<T> service);
+
+	/**
+	 * Invoke a service request using PCCC unconnected messaging, allowing for a
+	 * number of retries if the destination node returns an error status
+	 * indicating it is currently busy.
+	 *
+	 * @param service
+	 *            the service to invoke.
+	 * @param maxRetries
+	 *            the maximum number of retries to attempt.
+	 * @return a {@link CompletableFuture} containing the eventual service
+	 *         response or failure.
+	 */
+	<T> CompletableFuture<T> invokeUnconnected(PcccService<T> service, int maxRetries);
+}

--- a/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/ReadPcccTagService.java
+++ b/pccc-core/src/main/java/com/digitalpetri/enip/pccc/services/ReadPcccTagService.java
@@ -1,0 +1,119 @@
+package com.digitalpetri.enip.pccc.services;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.digitalpetri.enip.pccc.PcccResponseException;
+
+import io.netty.buffer.ByteBuf;
+
+//refer to http://literature.rockwellautomation.com/idc/groups/literature/documents/rm/1770-rm516_-en-p.pdf
+//refer section typed read (read block)
+public class ReadPcccTagService implements PcccService<ByteBuf> {
+	private static final String TAG_PATTERN = "(\\D*?)(\\d+):(\\d+)[/.]?(\\D*)";
+	private static final Pattern REGEX_PATTERN = Pattern.compile(TAG_PATTERN);
+
+	public static final int FUNCTION_CODE = 0x68;
+	public static final int PCCC_OFFSET = 0x0;
+
+	private final int tagFileNumber;
+	private final int tagElementNumber;
+	private final String tagSubElementStr;
+	private final int elementCount;
+
+	/**
+	 * Create a ReadPcccTagService requesting 1 element at {@code requestPath}.
+	 *
+	 * @param requestPath
+	 *            the path to the tag to read.
+	 */
+	public ReadPcccTagService(String tagName) {
+		this(tagName, 1);
+	}
+
+	/**
+	 * Create a ReadPcccTagService requesting {@code elementCount} elements at
+	 * {@code requestPath}.
+	 *
+	 * @param requestPath
+	 *            the path to the tag to read.
+	 * @param elementCount
+	 *            the number of elements to request.
+	 */
+	public ReadPcccTagService(String tagName, int elementCount) {
+		String trimmedTagName = tagName.replaceAll("\\s", "");
+
+		Matcher matcher = REGEX_PATTERN.matcher(trimmedTagName);
+		if (!matcher.matches())
+			throw new IllegalArgumentException("Invalid PCCC tag name: " + tagName);
+
+		this.tagFileNumber = Integer.parseInt(matcher.group(2));
+		this.tagElementNumber = Integer.parseInt(matcher.group(3));
+		this.tagSubElementStr = matcher.group(4).toLowerCase();
+		this.elementCount = elementCount;
+	}
+
+	@Override
+	public void encodeRequest(ByteBuf buffer) {
+		buffer.writeByte(FUNCTION_CODE);
+		buffer.writeShort(PCCC_OFFSET);
+		buffer.writeShort(elementCount);
+
+		// write tag name and length
+		encodeTag(buffer);
+		buffer.writeShort(elementCount);
+	}
+
+	@Override
+	public ByteBuf decodeResponse(ByteBuf buffer) throws PartialResponseException, PcccResponseException {
+		return buffer;
+	}
+
+	private void encodeTag(ByteBuf buffer) {
+		int subElementNumber = -1;
+
+		if (!tagSubElementStr.isEmpty()) {
+			switch (tagSubElementStr) {
+			case "acc":
+			case "pos":
+			case "sp":
+				subElementNumber = 2;
+				break;
+
+			case "len":
+			case "pre":
+				subElementNumber = 1;
+				break;
+			}
+		}
+
+		int levelByte = 0x7;
+		if (subElementNumber > -1)
+			levelByte = 0xF;
+
+		buffer.writeByte(levelByte);
+
+		// level 1
+		buffer.writeByte(0x0);
+
+		// level 2
+		if (tagFileNumber < 255)
+			buffer.writeByte(tagFileNumber);
+		else {
+			buffer.writeByte(0xFF);
+			buffer.writeShort(tagFileNumber);
+		}
+
+		// level 3
+		if (tagElementNumber < 255)
+			buffer.writeByte(tagElementNumber);
+		else {
+			buffer.writeByte(0xFF);
+			buffer.writeShort(tagElementNumber);
+		}
+
+		// level 4
+		if (subElementNumber > -1)
+			buffer.writeByte(subElementNumber);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>enip-client</module>
         <module>enip-core</module>
         <module>logix-services</module>
+        <module>pccc-core</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Added PCCC protocol support that allows communication with MicroLogix 1100/1400 and PLC-5 series.
References:
https://www.rockwellautomation.com/resources/downloads/rockwellautomation/pdf/sales-partners/technology-licensing/CIPandPCCC_v1_1.pdf (Section - Delivery of PCCC in CIP)
http://literature.rockwellautomation.com/idc/groups/literature/documents/rm/1770-rm516_-en-p.pdf (Section - Communication Commands -> typed read (read block))