### PR TITLE
Implement methods for sending unconnected messages directly

### DIFF
--- a/cip-core/src/main/java/com/digitalpetri/enip/cip/services/CipServiceInvoker.java
+++ b/cip-core/src/main/java/com/digitalpetri/enip/cip/services/CipServiceInvoker.java
@@ -5,6 +5,30 @@ import java.util.concurrent.CompletableFuture;
 public interface CipServiceInvoker {
 
     /**
+     * Invoke a service request using CIP unconnected messaging.
+     * <p>
+     * The service is invoked directly, without being passed through the Send_Unconnected service of the Connection
+     * Manager object.
+     *
+     * @param service the service to invoke.
+     * @return a {@link CompletableFuture} containing the eventual service response or failure.
+     */
+    <T> CompletableFuture<T> invoke(CipService<T> service);
+
+    /**
+     * Invoke a service request using CIP unconnected messaging, allowing for a number of retries if the destination
+     * node returns an error status indicating it is currently busy.
+     * <p>
+     * The service is invoked directly, without being passed through the Send_Unconnected service of the Connection
+     * Manager object.
+     *
+     * @param service    the service to invoke.
+     * @param maxRetries the maximum number of retries to attempt.
+     * @return a {@link CompletableFuture} containing the eventual service response or failure.
+     */
+    <T> CompletableFuture<T> invoke(CipService<T> service, int maxRetries);
+
+    /**
      * Invoke a service request using CIP connected messaging on the provided connection id.
      *
      * @param connectionId the id of the connection to use.
@@ -14,7 +38,8 @@ public interface CipServiceInvoker {
     <T> CompletableFuture<T> invokeConnected(int connectionId, CipService<T> service);
 
     /**
-     * Invoke a service request using CIP unconnected messaging.
+     * Invoke a service request using CIP unconnected messaging using the Send_Unconnected Service (0x52) of the
+     * Connection Manager object.
      *
      * @param service the service to invoke.
      * @return a {@link CompletableFuture} containing the eventual service response or failure.
@@ -22,8 +47,9 @@ public interface CipServiceInvoker {
     <T> CompletableFuture<T> invokeUnconnected(CipService<T> service);
 
     /**
-     * Invoke a service request using CIP unconnected messaging, allowing for a number of retries if the destination
-     * node returns an error status indicating it is currently busy.
+     * Invoke a service request using CIP unconnected messaging using the Send_Unconnected Service (0x52) of the
+     * Connection Manager object, allowing for a number of retries if the destination node returns an error status
+     * indicating it is currently busy.
      *
      * @param service    the service to invoke.
      * @param maxRetries the maximum number of retries to attempt.

--- a/cip-core/src/main/java/com/digitalpetri/enip/cip/services/CipServiceInvoker.java
+++ b/cip-core/src/main/java/com/digitalpetri/enip/cip/services/CipServiceInvoker.java
@@ -7,7 +7,7 @@ public interface CipServiceInvoker {
     /**
      * Invoke a service request using CIP unconnected messaging.
      * <p>
-     * The service is invoked directly, without being passed through the Send_Unconnected service of the Connection
+     * The service is invoked directly, without being passed through the Unconnected_Send service of the Connection
      * Manager object.
      *
      * @param service the service to invoke.
@@ -19,7 +19,7 @@ public interface CipServiceInvoker {
      * Invoke a service request using CIP unconnected messaging, allowing for a number of retries if the destination
      * node returns an error status indicating it is currently busy.
      * <p>
-     * The service is invoked directly, without being passed through the Send_Unconnected service of the Connection
+     * The service is invoked directly, without being passed through the Unconnected_Send service of the Connection
      * Manager object.
      *
      * @param service    the service to invoke.
@@ -38,7 +38,7 @@ public interface CipServiceInvoker {
     <T> CompletableFuture<T> invokeConnected(int connectionId, CipService<T> service);
 
     /**
-     * Invoke a service request using CIP unconnected messaging using the Send_Unconnected Service (0x52) of the
+     * Invoke a service request using CIP unconnected messaging using the Unconnected_Send Service (0x52) of the
      * Connection Manager object.
      *
      * @param service the service to invoke.
@@ -47,7 +47,7 @@ public interface CipServiceInvoker {
     <T> CompletableFuture<T> invokeUnconnected(CipService<T> service);
 
     /**
-     * Invoke a service request using CIP unconnected messaging using the Send_Unconnected Service (0x52) of the
+     * Invoke a service request using CIP unconnected messaging using the Unconnected_Send Service (0x52) of the
      * Connection Manager object, allowing for a number of retries if the destination node returns an error status
      * indicating it is currently busy.
      *


### PR DESCRIPTION
Support for the Unconnected_Send service of the Connection Manager
object is Conditional, only required by originators and implementations
that support routing between links. An additional method that sends
unconnected messages directly, without wrapping in the Unconnected_Send
service, is therefore required.